### PR TITLE
Add useSetImmerAtom hook

### DIFF
--- a/__tests__/useSetImmerAtom.test.tsx
+++ b/__tests__/useSetImmerAtom.test.tsx
@@ -1,0 +1,108 @@
+import React, { StrictMode } from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import { useAtomValue } from 'jotai'
+import { atom } from 'jotai/vanilla'
+import { atomWithImmer, useSetImmerAtom, withImmer } from '../src/index'
+
+it('useSetImmerAtom with regular atom', async () => {
+  const countAtom = atom(0)
+
+  const Parent = () => {
+    const count = useAtomValue(countAtom)
+    const setCount = useSetImmerAtom(countAtom)
+    return (
+      <>
+        <div>count: {count}</div>
+        <button onClick={() => setCount((draft) => (draft = draft + 1))}>
+          Increase
+        </button>
+        <button onClick={() => setCount((draft) => (draft = draft - 1))}>
+          Decrease
+        </button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <StrictMode>
+      <Parent />
+    </StrictMode>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('Increase'))
+  await findByText('count: 1')
+
+  fireEvent.click(getByText('Decrease'))
+  await findByText('count: 0')
+})
+
+it('useSetImmerAtom with immer atom', async () => {
+  const countAtom = atomWithImmer(0)
+
+  const Parent = () => {
+    const count = useAtomValue(countAtom)
+    const setCount = useSetImmerAtom(countAtom)
+    return (
+      <>
+        <div>count: {count}</div>
+        <button onClick={() => setCount((draft) => (draft = draft + 1))}>
+          Increase
+        </button>
+        <button onClick={() => setCount((draft) => (draft = draft - 1))}>
+          Decrease
+        </button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <StrictMode>
+      <Parent />
+    </StrictMode>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('Increase'))
+  await findByText('count: 1')
+
+  fireEvent.click(getByText('Decrease'))
+  await findByText('count: 0')
+})
+
+it('useSetImmerAtom with derived immer atom', async () => {
+  const regularCountAtom = atom(0)
+  const countAtom = withImmer(regularCountAtom)
+
+  const Parent = () => {
+    const count = useAtomValue(countAtom)
+    const setCount = useSetImmerAtom(countAtom)
+    return (
+      <>
+        <div>count: {count}</div>
+        <button onClick={() => setCount((draft) => (draft = draft + 1))}>
+          Increase
+        </button>
+        <button onClick={() => setCount((draft) => (draft = draft - 1))}>
+          Decrease
+        </button>
+      </>
+    )
+  }
+
+  const { findByText, getByText } = render(
+    <StrictMode>
+      <Parent />
+    </StrictMode>
+  )
+
+  await findByText('count: 0')
+
+  fireEvent.click(getByText('Increase'))
+  await findByText('count: 1')
+
+  fireEvent.click(getByText('Decrease'))
+  await findByText('count: 0')
+})

--- a/examples/04_useSetImmerAtom/package.json
+++ b/examples/04_useSetImmerAtom/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "jotai-immer-example",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "immer": "latest",
+    "jotai": "latest",
+    "jotai-immer": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "react-scripts": "latest",
+    "typescript": "latest"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/examples/04_useSetImmerAtom/public/index.html
+++ b/examples/04_useSetImmerAtom/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>jotai-immer example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/04_useSetImmerAtom/src/App.tsx
+++ b/examples/04_useSetImmerAtom/src/App.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { useAtomValue } from 'jotai'
+import { atom } from 'jotai/vanilla'
+import { useSetImmerAtom } from 'jotai-immer'
+
+const primitiveAtom = atom(0)
+
+const Counter = () => {
+  const count = useAtomValue(primitiveAtom)
+  return <div>count: {count}</div>
+}
+
+const Controls = () => {
+  const setCount = useSetImmerAtom(primitiveAtom)
+  // setCount === update : (draft: Draft<Value>) => void
+  const inc = () => setCount((c) => (c = c + 1))
+  return <button onClick={inc}>+1</button>
+}
+
+const App = () => (
+  <div>
+    <Counter />
+    <Controls />
+  </div>
+)
+
+export default App

--- a/examples/04_useSetImmerAtom/src/index.tsx
+++ b/examples/04_useSetImmerAtom/src/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+const ele = document.getElementById('app')
+if (ele) {
+  createRoot(ele).render(React.createElement(App))
+}

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "peerDependencies": {
     "immer": "*",
-    "jotai": ">=1.11.0",
+    "jotai": ">=2.0.0",
     "react": ">=17.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { atomWithImmer } from './atomWithImmer'
 export { withImmer } from './withImmer'
 export { useImmerAtom } from './useImmerAtom'
+export { useSetImmerAtom } from './useSetImmerAtom'

--- a/src/useImmerAtom.ts
+++ b/src/useImmerAtom.ts
@@ -1,5 +1,5 @@
 import type { Draft } from 'immer'
-import { useAtom, useAtomValue } from 'jotai/react'
+import { useAtomValue } from 'jotai/react'
 import type { WritableAtom } from 'jotai/vanilla'
 import { useSetImmerAtom } from './useSetImmerAtom'
 

--- a/src/useImmerAtom.ts
+++ b/src/useImmerAtom.ts
@@ -3,7 +3,7 @@ import { useAtom, useAtomValue } from 'jotai/react'
 import type { WritableAtom } from 'jotai/vanilla'
 import { useSetImmerAtom } from './useSetImmerAtom'
 
-type Options = Parameters<typeof useAtom>[1]
+type Options = Parameters<typeof useAtomValue>[1]
 
 export function useImmerAtom<Value, Result>(
   anAtom: WritableAtom<Value, [(draft: Draft<Value>) => void], Result>,

--- a/src/useImmerAtom.ts
+++ b/src/useImmerAtom.ts
@@ -1,29 +1,23 @@
-import { useCallback } from 'react'
-import { produce } from 'immer'
 import type { Draft } from 'immer'
-import { useAtom } from 'jotai/react'
+import { useAtom, useAtomValue } from 'jotai/react'
 import type { WritableAtom } from 'jotai/vanilla'
+import { useSetImmerAtom } from './useSetImmerAtom'
 
-type Scope = NonNullable<Parameters<typeof useAtom>[1]>
+type Options = Parameters<typeof useAtom>[1]
 
 export function useImmerAtom<Value, Result>(
   anAtom: WritableAtom<Value, [(draft: Draft<Value>) => void], Result>,
-  scope?: Scope
+  options?: Options
 ): [Value, (fn: (draft: Draft<Value>) => void) => Result]
 
 export function useImmerAtom<Value, Result>(
   anAtom: WritableAtom<Value, [(value: Value) => Value], Result>,
-  scope?: Scope
+  options?: Options
 ): [Value, (fn: (draft: Draft<Value>) => void) => Result]
 
 export function useImmerAtom<Value, Result>(
   anAtom: WritableAtom<Value, [(value: Value) => Value], Result>,
-  scope?: Scope
+  options?: Options
 ) {
-  const [state, setState] = useAtom(anAtom, scope)
-  const setStateWithImmer = useCallback(
-    (fn: (draft: Draft<Value>) => void) => setState(produce(fn)),
-    [setState]
-  )
-  return [state, setStateWithImmer]
+  return [useAtomValue(anAtom, options), useSetImmerAtom(anAtom, options)]
 }

--- a/src/useSetImmerAtom.ts
+++ b/src/useSetImmerAtom.ts
@@ -4,7 +4,7 @@ import type { Draft } from 'immer'
 import { useAtom, useSetAtom } from 'jotai/react'
 import type { WritableAtom } from 'jotai/vanilla'
 
-type Options = Parameters<typeof useAtom>[1]
+type Options = Parameters<typeof useSetAtom>[1]
 
 export function useSetImmerAtom<Value, Result>(
   anAtom: WritableAtom<Value, [(draft: Draft<Value>) => void], Result>,

--- a/src/useSetImmerAtom.ts
+++ b/src/useSetImmerAtom.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { produce } from 'immer'
 import type { Draft } from 'immer'
-import { useAtom, useSetAtom } from 'jotai/react'
+import { useSetAtom } from 'jotai/react'
 import type { WritableAtom } from 'jotai/vanilla'
 
 type Options = Parameters<typeof useSetAtom>[1]

--- a/src/useSetImmerAtom.ts
+++ b/src/useSetImmerAtom.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react'
+import { produce } from 'immer'
+import type { Draft } from 'immer'
+import { useAtom, useSetAtom } from 'jotai/react'
+import type { WritableAtom } from 'jotai/vanilla'
+
+type Options = Parameters<typeof useAtom>[1]
+
+export function useSetImmerAtom<Value, Result>(
+  anAtom: WritableAtom<Value, [(draft: Draft<Value>) => void], Result>,
+  options?: Options
+): (fn: (draft: Draft<Value>) => void) => Result
+
+export function useSetImmerAtom<Value, Result>(
+  anAtom: WritableAtom<Value, [(value: Value) => Value], Result>,
+  options?: Options
+): (fn: (draft: Draft<Value>) => void) => Result
+
+export function useSetImmerAtom<Value, Result>(
+  anAtom: WritableAtom<Value, [(value: Value) => Value], Result>,
+  options?: Options
+) {
+  const setState = useSetAtom(anAtom, options)
+  return useCallback(
+    (fn: (draft: Draft<Value>) => void) => setState(produce(fn)),
+    [setState]
+  )
+}


### PR DESCRIPTION
Adds a hook that returns a `setState` immer-style function only.

Updates the `jotai` peer dep to >=2.0.0.

There is also a change in the signature of the `useImmerAtom` hook, which makes it type-incompatible for users of `jotai` v1.